### PR TITLE
added gunicorn to manage.py and dependency

### DIFF
--- a/gateway/manage.py
+++ b/gateway/manage.py
@@ -1,8 +1,28 @@
-from flask_script import Manager
+from flask_script import Manager, Command, Option
 from unittest import TestLoader, TextTestRunner
 from gateway import gateway
 
 manager = Manager(gateway.get_service())
+
+@manager.option('-h', '--host', dest='host', default='127.0.0.1')
+@manager.option('-p', '--port', dest='port', type=int, default=3000)
+@manager.option('-w', '--workers', dest='workers', type=int, default=3)
+def gunicorn(host, port, workers):
+    """Start the Server with Gunicorn"""
+    from gunicorn.app.base import Application
+
+    class FlaskApplication(Application):
+        def init(self, parser, opts, args):
+            return {
+                'bind': '{0}:{1}'.format(host, port),
+                'workers': workers
+            }
+
+        def load(self):
+            return gateway.get_service()
+
+    application = FlaskApplication()
+    return application.run()
 
 @manager.command
 def test():

--- a/gateway/manage.py
+++ b/gateway/manage.py
@@ -1,4 +1,4 @@
-from flask_script import Manager, Command, Option
+from flask_script import Manager
 from unittest import TestLoader, TextTestRunner
 from gateway import gateway
 

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -17,6 +17,7 @@ Flask-OIDC==1.4.0
 Flask-RESTful==0.3.6
 flask-restful-swagger-2==0.35
 Flask-Script==2.0.6
+gunicorn==19.9.0
 httplib2==0.11.3
 isort==4.3.4
 itsdangerous==0.24


### PR DESCRIPTION
server can now be started with gunicorn:

`python manage.py gunicorn -h <HOST> -p <PORT> -w <NO_WORKERS>`

We can also see how to include this in the dockerfile, should be straightforward.