### PR TITLE
Remove alpine

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,3 @@
-#FROM python:3.6-alpine
 FROM python:3.6
 # Add use rwith gid 1000 (important), gid also 1000 to be sure
 ENV USER=www-openeo
@@ -12,9 +11,6 @@ RUN addgroup --gid "$GID" "$GROUP" \
     --ingroup "$GROUP" \
     --uid "$UID" \
     "$USER"
-# RUN apk update && \
-#     apk add --no-cache build-base libressl-dev libffi-dev gcc python3-dev musl-dev postgresql-dev git vim nano bash&& \
-#     pip3 install --upgrade pip
 RUN pip3 install --upgrade pip
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6.11
 # Add use rwith gid 1000 (important), gid also 1000 to be sure
 ENV USER=www-openeo
 ENV UID=1000
@@ -11,7 +11,7 @@ RUN addgroup --gid "$GID" "$GROUP" \
     --ingroup "$GROUP" \
     --uid "$UID" \
     "$USER"
-RUN pip3 install --upgrade pip
+RUN apt-get update && apt-get install netcat -y && pip3 install --upgrade pip
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY requirements.txt .

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,10 @@ RUN addgroup --gid "$GID" "$GROUP" \
     --ingroup "$GROUP" \
     --uid "$UID" \
     "$USER"
-RUN apt-get update && apt-get install netcat -y && pip3 install --upgrade pip
+RUN apt-get update && \
+    apt-get install --no-install-recommends netcat -y && \
+    apt-get clean && \
+    apt-get autoclean
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY requirements.txt .

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.6-alpine
+#FROM python:3.6-alpine
+FROM python:3.6
 # Add use rwith gid 1000 (important), gid also 1000 to be sure
 ENV USER=www-openeo
 ENV UID=1000
@@ -11,9 +12,10 @@ RUN addgroup --gid "$GID" "$GROUP" \
     --ingroup "$GROUP" \
     --uid "$UID" \
     "$USER"
-RUN apk update && \
-    apk add build-base libressl-dev libffi-dev gcc python3-dev musl-dev postgresql-dev git && \
-    pip3 install --upgrade pip
+# RUN apk update && \
+#     apk add --no-cache build-base libressl-dev libffi-dev gcc python3-dev musl-dev postgresql-dev git vim nano bash&& \
+#     pip3 install --upgrade pip
+RUN pip3 install --upgrade pip
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY requirements.txt .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     build:
       context: ./gateway
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     container_name: oeo-gateway-$OPENEO_VERSION
     restart: on-failure
     depends_on:
@@ -67,7 +67,7 @@ services:
       - $SYNC_RESULTS_FOLDER:/usr/src/sync-results
       - $LOG_DIR:/usr/src/logs
     environment:
-      OEO_OPENEO_VERSION: $OPENEO_VERSION
+      OOPENEO_VERSION: $OPENEO_VERSION
     ports:
       - $GATEWAY_PORT:3000
 
@@ -75,7 +75,7 @@ services:
     build:
       context: ./services/capabilities
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-capabilities-$OPENEO_VERSION
     container_name: oeo-capabilities-$OPENEO_VERSION
     restart: on-failure
@@ -97,7 +97,7 @@ services:
     build:
       context: ./services/data
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-data-$OPENEO_VERSION
     container_name: oeo-data-$OPENEO_VERSION
     restart: on-failure
@@ -122,7 +122,7 @@ services:
     build:
       context: ./services/processes
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-processes-$OPENEO_VERSION
     container_name: oeo-processes-$OPENEO_VERSION
     restart: on-failure
@@ -135,7 +135,7 @@ services:
       - ./envs/rabbitmq.env
       - ./envs/processes.env
     environment:
-      OEO_OPENEO_VERSION: $OPENEO_VERSION
+      OPENEO_VERSION: $OPENEO_VERSION
       PROCESS_API_DIR: /usr/src/api
       LOG_DIR: /usr/src/logs
     volumes:
@@ -147,7 +147,7 @@ services:
     build: 
       context: ./services/jobs
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-jobs-$OPENEO_VERSION
     container_name: oeo-jobs-$OPENEO_VERSION
     restart: on-failure
@@ -178,7 +178,7 @@ services:
     build:
       context: ./services/files
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-files-$OPENEO_VERSION
     container_name: oeo-files-$OPENEO_VERSION
     restart: on-failure

--- a/docker-compose_dev.yml
+++ b/docker-compose_dev.yml
@@ -59,7 +59,7 @@ services:
     build:
       context: ./gateway
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     container_name: oeo-gateway-$OPENEO_VERSION
     restart: on-failure
     depends_on:
@@ -84,7 +84,7 @@ services:
     build:
       context: ./services/capabilities
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-capabilities-$OPENEO_VERSION
     container_name: oeo-capabilities-$OPENEO_VERSION
     restart: on-failure
@@ -105,7 +105,7 @@ services:
     build:
       context: ./services/data
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-data-$OPENEO_VERSION
     container_name: oeo-data-$OPENEO_VERSION
     restart: on-failure
@@ -130,7 +130,7 @@ services:
     build:
       context: ./services/processes
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-processes-$OPENEO_VERSION
     container_name: oeo-processes-$OPENEO_VERSION
     restart: on-failure
@@ -155,7 +155,7 @@ services:
     build: 
       context: ./services/jobs
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-jobs-$OPENEO_VERSION
     container_name: oeo-jobs-$OPENEO_VERSION
     restart: on-failure
@@ -186,7 +186,7 @@ services:
     build:
       context: ./services/files
       args:
-        OEO_OPENEO_VERSION: $OPENEO_VERSION
+        OPENEO_VERSION: $OPENEO_VERSION
     image: oeo-files-$OPENEO_VERSION
     container_name: oeo-files-$OPENEO_VERSION
     restart: on-failure

--- a/services/processes/processes/service.py
+++ b/services/processes/processes/service.py
@@ -9,7 +9,7 @@ from dynaconf import settings
 from jsonschema import ValidationError
 from nameko.rpc import RpcProxy, rpc
 from nameko_sqlalchemy import DatabaseSession
-from openeo_pg_parser_python.validate import validate_process_graph
+from openeo_pg_parser.validate import validate_process_graph
 
 from .dependencies.settings import initialise_settings
 from .models import Base, ProcessDefinitionEnum, ProcessGraph


### PR DESCRIPTION
- fix issues with installing python-pg-parser on jobs and processes services, isnce the dependency python-igraph has to be compiled but other packages to do that are missing in the alpine-based image
- to simplify installation, all images are now based on python:3.6 even if it increases all images size